### PR TITLE
Added support rtl languages in HStackView + activation constrains by scope

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftyUIKit",
     platforms: [
-       .iOS(.v9)
+       .iOS(.v11)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -142,7 +142,11 @@ or
 }
 
 ```
+
+#### Right-to-left languages
                    
+HStackView supports right-to-left languages by default.
+Use `semanticContentAttribute = .forceLeftToRight` if you want to force direction.
 
 ## Installation
 

--- a/Sources/SwiftyUIKit/HStackView.swift
+++ b/Sources/SwiftyUIKit/HStackView.swift
@@ -21,7 +21,7 @@ public final class HStackView: UIView {
     public init(spacing: CGFloat = 0,
                 content: [UIView]) {
         super.init(frame: .zero)
-        var constrains = [NSLayoutConstraint]()
+        var constraints = [NSLayoutConstraint]()
         translatesAutoresizingMaskIntoConstraints = false
         content
             .enumerated()
@@ -33,26 +33,26 @@ public final class HStackView: UIView {
                 view.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(view)
                 
-                constrains.append(view.topAnchor.constraint(equalTo: topAnchor))
-                constrains.append(view.bottomAnchor.constraint(equalTo: bottomAnchor))
+                constraints.append(view.topAnchor.constraint(equalTo: topAnchor))
+                constraints.append(view.bottomAnchor.constraint(equalTo: bottomAnchor))
 
                 if isFirst {
-                    constrains.append(view.leadingAnchor.constraint(equalTo: leadingAnchor))
+                    constraints.append(view.leadingAnchor.constraint(equalTo: leadingAnchor))
                 }
 
                 if let prevView {
-                    constrains.append(view.leadingAnchor.constraint(
+                    constraints.append(view.leadingAnchor.constraint(
                         equalTo: prevView.trailingAnchor,
                         constant: spacing))
                 }
 
                 if isLast {
-                    constrains.append(view.trailingAnchor.constraint(equalTo: trailingAnchor))
+                    constraints.append(view.trailingAnchor.constraint(equalTo: trailingAnchor))
                 }
             }
         
-        constrains.forEach { $0.priority = .defaultHigh }
-        NSLayoutConstraint.activate(constrains)
+        constraints.forEach { $0.priority = .defaultHigh }
+        NSLayoutConstraint.activate(constraints)
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/SwiftyUIKit/HStackView.swift
+++ b/Sources/SwiftyUIKit/HStackView.swift
@@ -15,7 +15,6 @@ public extension HStackView {
     convenience init(spacing: CGFloat = 0, @OptionalViewContentBuilder optionalContent: () -> [UIView]) {
         self.init(spacing: spacing, content: optionalContent())
     }
-
 }
 
 public final class HStackView: UIView {

--- a/Sources/SwiftyUIKit/HStackView.swift
+++ b/Sources/SwiftyUIKit/HStackView.swift
@@ -48,8 +48,8 @@ public final class HStackView: UIView {
                     }
 
                 if isFirst {
-                    view.leftAnchor
-                        .constraint(equalTo: leftAnchor)
+                    view.leadingAnchor
+                        .constraint(equalTo: leadingAnchor)
                         .modify {
                             $0.priority = .defaultHigh
                             $0.isActive = true
@@ -57,8 +57,8 @@ public final class HStackView: UIView {
                 }
 
                 if let prevView = previousView {
-                    view.leftAnchor
-                        .constraint(equalTo: prevView.rightAnchor,
+                    view.leadingAnchor
+                        .constraint(equalTo: prevView.trailingAnchor,
                                     constant: spacing)
                         .modify {
                             $0.priority = .defaultHigh
@@ -67,8 +67,8 @@ public final class HStackView: UIView {
                 }
 
                 if isLast {
-                    view.rightAnchor
-                        .constraint(equalTo: rightAnchor)
+                    view.trailingAnchor
+                        .constraint(equalTo: trailingAnchor)
                         .modify {
                             $0.priority = .defaultHigh
                             $0.isActive = true

--- a/Sources/SwiftyUIKit/HStackView.swift
+++ b/Sources/SwiftyUIKit/HStackView.swift
@@ -28,7 +28,7 @@ public final class HStackView: UIView {
             .forEach { (index, view) in
                 let isFirst = index == 0
                 let isLast = index == content.count - 1
-                let previousView: UIView? = isFirst ? nil : content[index - 1]
+                let prevView: UIView? = isFirst ? nil : content[index - 1]
 
                 view.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(view)
@@ -40,7 +40,7 @@ public final class HStackView: UIView {
                     constrains.append(view.leadingAnchor.constraint(equalTo: leadingAnchor))
                 }
 
-                if let prevView = previousView {
+                if let prevView {
                     constrains.append(view.leadingAnchor.constraint(
                         equalTo: prevView.trailingAnchor,
                         constant: spacing))

--- a/Sources/SwiftyUIKit/HStackView.swift
+++ b/Sources/SwiftyUIKit/HStackView.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  HStackView.swift
 //  
 //
 //  Created by Sergey Kazakov on 30.11.2020.

--- a/Sources/SwiftyUIKit/HStackView.swift
+++ b/Sources/SwiftyUIKit/HStackView.swift
@@ -21,6 +21,7 @@ public final class HStackView: UIView {
     public init(spacing: CGFloat = 0,
                 content: [UIView]) {
         super.init(frame: .zero)
+        var constrains = [NSLayoutConstraint]()
         translatesAutoresizingMaskIntoConstraints = false
         content
             .enumerated()
@@ -31,49 +32,27 @@ public final class HStackView: UIView {
 
                 view.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(view)
-
-                view.topAnchor
-                    .constraint(equalTo: topAnchor)
-                    .modify {
-                        $0.priority = .defaultHigh
-                        $0.isActive = true
-                    }
-
-                view.bottomAnchor
-                    .constraint(equalTo: bottomAnchor)
-                    .modify {
-                        $0.priority = .defaultHigh
-                        $0.isActive = true
-                    }
+                
+                constrains.append(view.topAnchor.constraint(equalTo: topAnchor))
+                constrains.append(view.bottomAnchor.constraint(equalTo: bottomAnchor))
 
                 if isFirst {
-                    view.leadingAnchor
-                        .constraint(equalTo: leadingAnchor)
-                        .modify {
-                            $0.priority = .defaultHigh
-                            $0.isActive = true
-                        }
+                    constrains.append(view.leadingAnchor.constraint(equalTo: leadingAnchor))
                 }
 
                 if let prevView = previousView {
-                    view.leadingAnchor
-                        .constraint(equalTo: prevView.trailingAnchor,
-                                    constant: spacing)
-                        .modify {
-                            $0.priority = .defaultHigh
-                            $0.isActive = true
-                        }
+                    constrains.append(view.leadingAnchor.constraint(
+                        equalTo: prevView.trailingAnchor,
+                        constant: spacing))
                 }
 
                 if isLast {
-                    view.trailingAnchor
-                        .constraint(equalTo: trailingAnchor)
-                        .modify {
-                            $0.priority = .defaultHigh
-                            $0.isActive = true
-                        }
+                    constrains.append(view.trailingAnchor.constraint(equalTo: trailingAnchor))
                 }
             }
+        
+        constrains.forEach { $0.priority = .defaultHigh }
+        NSLayoutConstraint.activate(constrains)
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/SwiftyUIKit/Modifiable.swift
+++ b/Sources/SwiftyUIKit/Modifiable.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Modifiable.swift
 //
 //
 //  Created by Sergey Kazakov on 01.12.2020.

--- a/Sources/SwiftyUIKit/SpacerView.swift
+++ b/Sources/SwiftyUIKit/SpacerView.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SpacerView.swift
 //  
 //
 //  Created by Sergey Kazakov on 30.11.2020.

--- a/Sources/SwiftyUIKit/UIView+Padding.swift
+++ b/Sources/SwiftyUIKit/UIView+Padding.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  UIView+Padding.swift
 //  
 //
 //  Created by Sergey Kazakov on 22.09.2020.

--- a/Sources/SwiftyUIKit/UIView+Snap.swift
+++ b/Sources/SwiftyUIKit/UIView+Snap.swift
@@ -15,11 +15,11 @@ public extension UIView {
 
 internal extension UIView {
     enum FlexibleEdge: Int, Equatable, CaseIterable {
-           case top
-           case left
-           case right
-           case bottom
-       }
+        case top
+        case left
+        case right
+        case bottom
+    }
 }
 
 internal extension UIView {

--- a/Sources/SwiftyUIKit/UIView+Snap.swift
+++ b/Sources/SwiftyUIKit/UIView+Snap.swift
@@ -24,7 +24,7 @@ internal extension UIView {
 
 internal extension UIView {
     func snapSubview(_ subview: UIView,
-                     flexibleEdges edges: [FlexibleEdge] = [],
+                     flexibleEdges: [FlexibleEdge] = [],
                      center: Bool = false) {
         addSubview(subview)
         subview.translatesAutoresizingMaskIntoConstraints = false
@@ -35,7 +35,9 @@ internal extension UIView {
                 subview.centerXAnchor.constraint(equalTo: centerXAnchor)
             ])
         }
-
+        
+        let edges = Set(flexibleEdges)
+        
         NSLayoutConstraint.activate([
             edges.contains(.left) ?
                 subview.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor)

--- a/Sources/SwiftyUIKit/UIView+Snap.swift
+++ b/Sources/SwiftyUIKit/UIView+Snap.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  UIView+Snap.swift
 //  
 //
 //  Created by Sergey Kazakov on 30.11.2020.

--- a/Sources/SwiftyUIKit/UIView+Snap.swift
+++ b/Sources/SwiftyUIKit/UIView+Snap.swift
@@ -24,7 +24,7 @@ internal extension UIView {
 
 internal extension UIView {
     func snapSubview(_ subview: UIView,
-                     flexibleEdges: [FlexibleEdge]? = nil,
+                     flexibleEdges edges: [FlexibleEdge] = [],
                      center: Bool = false) {
         addSubview(subview)
         subview.translatesAutoresizingMaskIntoConstraints = false
@@ -35,18 +35,6 @@ internal extension UIView {
                 subview.centerXAnchor.constraint(equalTo: centerXAnchor)
             ])
         }
-
-        guard let flexibleEdges = flexibleEdges else {
-            NSLayoutConstraint.activate([
-                subview.leftAnchor.constraint(equalTo: leftAnchor),
-                subview.rightAnchor.constraint(equalTo: rightAnchor),
-                subview.topAnchor.constraint(equalTo: topAnchor),
-                subview.bottomAnchor.constraint(equalTo: bottomAnchor)
-            ])
-            return
-        }
-
-        let edges = Set(flexibleEdges)
 
         NSLayoutConstraint.activate([
             edges.contains(.left) ?

--- a/Sources/SwiftyUIKit/VStackView.swift
+++ b/Sources/SwiftyUIKit/VStackView.swift
@@ -21,7 +21,7 @@ public final class VStackView: UIView {
     public init(spacing: CGFloat = 0,
                 content: [UIView]) {
         super.init(frame: .zero)
-        var constrains = [NSLayoutConstraint]()
+        var constraints = [NSLayoutConstraint]()
         translatesAutoresizingMaskIntoConstraints = false
         content
             .enumerated()
@@ -33,26 +33,26 @@ public final class VStackView: UIView {
                 view.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(view)
                 
-                constrains.append(view.leftAnchor.constraint(equalTo: leftAnchor))
-                constrains.append(view.rightAnchor.constraint(equalTo: rightAnchor))
+                constraints.append(view.leftAnchor.constraint(equalTo: leftAnchor))
+                constraints.append(view.rightAnchor.constraint(equalTo: rightAnchor))
      
                 if isFirst {
-                    constrains.append(view.topAnchor.constraint(equalTo: topAnchor))
+                    constraints.append(view.topAnchor.constraint(equalTo: topAnchor))
                 }
 
                 if let prevView {
-                    constrains.append(view.topAnchor.constraint(
+                    constraints.append(view.topAnchor.constraint(
                         equalTo: prevView.bottomAnchor,
                         constant: spacing))
                 }
 
                 if isLast {
-                    constrains.append(view.bottomAnchor.constraint(equalTo: bottomAnchor))
+                    constraints.append(view.bottomAnchor.constraint(equalTo: bottomAnchor))
                 }
             }
         
-        constrains.forEach { $0.priority = .defaultHigh }
-        NSLayoutConstraint.activate(constrains)
+        constraints.forEach { $0.priority = .defaultHigh }
+        NSLayoutConstraint.activate(constraints)
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/SwiftyUIKit/VStackView.swift
+++ b/Sources/SwiftyUIKit/VStackView.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  VStackView.swift
 //  
 //
 //  Created by Sergey Kazakov on 30.11.2020.

--- a/Sources/SwiftyUIKit/VStackView.swift
+++ b/Sources/SwiftyUIKit/VStackView.swift
@@ -21,7 +21,7 @@ public final class VStackView: UIView {
     public init(spacing: CGFloat = 0,
                 content: [UIView]) {
         super.init(frame: .zero)
-
+        var constrains = [NSLayoutConstraint]()
         translatesAutoresizingMaskIntoConstraints = false
         content
             .enumerated()
@@ -32,49 +32,27 @@ public final class VStackView: UIView {
 
                 view.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(view)
-
-                view.leftAnchor
-                    .constraint(equalTo: leftAnchor)
-                    .modify {
-                        $0.priority = .defaultHigh
-                        $0.isActive = true
-                    }
-
-                view.rightAnchor
-                    .constraint(equalTo: rightAnchor)
-                    .modify {
-                        $0.priority = .defaultHigh
-                        $0.isActive = true
-                    }
-
+                
+                constrains.append(view.leftAnchor.constraint(equalTo: leftAnchor))
+                constrains.append(view.rightAnchor.constraint(equalTo: rightAnchor))
+     
                 if isFirst {
-                    view.topAnchor
-                        .constraint(equalTo: topAnchor)
-                        .modify {
-                            $0.priority =  .defaultHigh
-                            $0.isActive = true
-                        }
+                    constrains.append(view.topAnchor.constraint(equalTo: topAnchor))
                 }
 
                 if let prevView = previousView {
-                    view.topAnchor
-                        .constraint(equalTo: prevView.bottomAnchor,
-                                    constant: spacing)
-                        .modify {
-                            $0.priority =  .defaultHigh
-                            $0.isActive = true
-                        }
+                    constrains.append(view.topAnchor.constraint(
+                        equalTo: prevView.bottomAnchor,
+                        constant: spacing))
                 }
 
                 if isLast {
-                    view.bottomAnchor
-                        .constraint(equalTo: bottomAnchor)
-                        .modify {
-                            $0.priority =  .defaultHigh
-                            $0.isActive = true
-                        }
+                    constrains.append(view.bottomAnchor.constraint(equalTo: bottomAnchor))
                 }
             }
+        
+        constrains.forEach { $0.priority = .defaultHigh }
+        NSLayoutConstraint.activate(constrains)
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/SwiftyUIKit/VStackView.swift
+++ b/Sources/SwiftyUIKit/VStackView.swift
@@ -28,7 +28,7 @@ public final class VStackView: UIView {
             .forEach { (index, view) in
                 let isFirst = index == 0
                 let isLast = index == content.count - 1
-                let previousView: UIView? = isFirst ? nil : content[index - 1]
+                let prevView: UIView? = isFirst ? nil : content[index - 1]
 
                 view.translatesAutoresizingMaskIntoConstraints = false
                 addSubview(view)
@@ -40,7 +40,7 @@ public final class VStackView: UIView {
                     constrains.append(view.topAnchor.constraint(equalTo: topAnchor))
                 }
 
-                if let prevView = previousView {
+                if let prevView {
                     constrains.append(view.topAnchor.constraint(
                         equalTo: prevView.bottomAnchor,
                         constant: spacing))

--- a/Sources/SwiftyUIKit/ViewContentBuilder.swift
+++ b/Sources/SwiftyUIKit/ViewContentBuilder.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ViewContentBuilder.swift
 //  
 //
 //  Created by Sergey Kazakov on 30.11.2020.

--- a/Sources/SwiftyUIKit/ZStackView.swift
+++ b/Sources/SwiftyUIKit/ZStackView.swift
@@ -43,7 +43,7 @@ public final class ZStackView: UIView {
             case .bottom:
                 snapSubview($0, flexibleEdges: [.top])
             case .all:
-                snapSubview($0, flexibleEdges: nil)
+                snapSubview($0)
             case .center:
                 snapSubview($0, flexibleEdges: FlexibleEdge.allCases, center: true)
             case .vertical:

--- a/Sources/SwiftyUIKit/ZStackView.swift
+++ b/Sources/SwiftyUIKit/ZStackView.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ZStackView.swift
 //  
 //
 //  Created by Sergey Kazakov on 30.11.2020.


### PR DESCRIPTION
Hello Sergey 👋

1. For Right-to-Left languages (Arabic and Hebrew) you need to change the direction of views in HStackView.
For example, UIStackView do it by default.


<img width="284" alt="Screenshot 2022-11-03 at 11 36 52" src="https://user-images.githubusercontent.com/973364/199668233-e97f3474-456e-4e13-ac5a-c8ec99c8133b.png">
<img width="286" alt="Screenshot 2022-11-03 at 11 37 02" src="https://user-images.githubusercontent.com/973364/199668236-5c5a4f74-9bc8-4a0c-90e9-d90b6793324e.png">

2. Activation constrains by scope is more efficient. Apple documentation says:

```
 /* Convenience method that activates each constraint
 in the contained array, in the same manner as setting active=YES.
 This is often more efficient than activating each constraint individually. */
@available(iOS 8.0, *)
open class func activate(_ constraints: [NSLayoutConstraint])
```